### PR TITLE
Adds a retry method to HttpClient

### DIFF
--- a/R/asyncvaried.R
+++ b/R/asyncvaried.R
@@ -237,7 +237,10 @@ AsyncVaried <- R6::R6Class(
             curl::multi_add(
               handle = h,
               done = function(res) multi_res[[i]] <<- res,
-              fail = function(res) multi_res[[i]] <<- make_async_error(res, w),
+              fail = function(res) {
+                close(ff)
+                multi_res[[i]] <<- make_async_error(res, w)
+              },
               data = ff,
               pool = crulpool
             )

--- a/R/asyncvaried.R
+++ b/R/asyncvaried.R
@@ -236,7 +236,10 @@ AsyncVaried <- R6::R6Class(
             ff <- file(w$disk, open = "wb")
             curl::multi_add(
               handle = h,
-              done = function(res) multi_res[[i]] <<- res,
+              done = function(res) {
+                close(ff)
+                multi_res[[i]] <<- res
+              },
               fail = function(res) {
                 close(ff)
                 multi_res[[i]] <<- make_async_error(res, w)

--- a/R/body.R
+++ b/R/body.R
@@ -33,13 +33,15 @@ prep_body <- function(body, encode, type = NULL) {
     return(raw_body(body, type = type))
   }
   if (inherits(body, "form_file")) {
-    con <- file(body$path, "rb")
-    size <- file.info(body$path)$size
+    filePath <- body$path
+    size <- file.info(filePath)$size
+    con <- NULL
     return(
       list(
         opts = list(
           post = TRUE,
           readfunction = function(nbytes, ...) {
+            if (is.null(con)) con <<- file(filePath, "rb")
             if (is.null(con)) return(raw())
             bin <- readBin(con, "raw", nbytes)
             if (length(bin) < nbytes) {

--- a/man/HttpClient.Rd
+++ b/man/HttpClient.Rd
@@ -48,6 +48,12 @@ Make a DELETE request
 \item{\code{head(path, query, ...)}}{
 Make a HEAD request
 }
+\item{\code{retry(verb, ..., pause_base = 1, pause_cap = 60, pause_min = 1, times = 3, terminate_on, retry_only_on)}}{
+Retries the request given by \code{verb} until successful (HTTP response
+status < 400), or a condition for giving up is met. Automatically
+recognizes \code{Retry-After} and \code{X-RateLimit-Reset} headers in the
+response for rate-limited remote APIs.
+}
 \item{\code{handle_pop()}}{
 reset your curl handle
 }
@@ -61,22 +67,36 @@ parameters; body and any curl options don't change the URL
 
 Possible parameters (not all are allowed in each HTTP verb):
 \itemize{
-\item path - URL path, appended to the base URL
-\item query - query terms, as a named list
-\item body - body as an R list
-\item encode - one of form, multipart, json, or raw
-\item disk - a path to write to. if NULL (default), memory used.
+\item \code{path} - URL path, appended to the base URL
+\item \code{query} - query terms, as a named list
+\item \code{body} - body as an R list
+\item \code{encode} - one of form, multipart, json, or raw
+\item \code{disk} - a path to write to. if NULL (default), memory used.
 See \code{\link[curl:curl_fetch_disk]{curl::curl_fetch_disk()}} for help.
-\item stream - an R function to determine how to stream data. if
+\item \code{stream} - an R function to determine how to stream data. if
 NULL (default), memory used. See \code{\link[curl:curl_fetch_stream]{curl::curl_fetch_stream()}}
 for help
-\item ... curl options, only those in the acceptable set from
-\code{\link[curl:curl_options]{curl::curl_options()}} except the following: httpget, httppost,
-post, postfields, postfieldsize, and customrequest
+\item \code{...} For \code{retry}, the options to be passed on to the method
+implementing the requested verb, including curl options. Otherwise,
+curl options, only those in the acceptable set from \code{\link[curl:curl_options]{curl::curl_options()}}
+except the following: httpget, httppost, post, postfields, postfieldsize,
+and customrequest
+\item \code{pause_base,pause_cap,pause_min} - basis, maximum, and minimum for
+calculating wait time for retry. Wait time is calculated according to the
+exponential backoff with full jitter algorithm. Specifically, wait time is
+chosen randomly between \code{pause_min} and the lesser of \code{pause_base * 2} and
+\code{pause_cap}, with \code{pause_base} doubling on each subsequent retry attempt.
+Use \code{pause_cap = Inf} to not terminate retrying due to cap of wait time
+reached.
+\item \code{times} - the maximum number of times to retry. Set to \code{Inf} to
+not stop retrying due to exhausting the number of attempts.
+\item \code{terminate_on,retry_only_on} - a vector of HTTP status codes. For
+\code{terminate_on}, the status codes for which to terminate retrying, and for
+\code{retry_only_on}, the status codes for which to retry the request.
 }
 }
 \note{
-a little quark about \code{crul} is that because user agent string can
+A little quirk about \code{crul} is that because user agent string can
 be passed as either a header or a curl option (both lead to a \code{User-Agent}
 header being passed in the HTTP request), we return the user agent
 string in the \code{request_headers} list of the response even if you
@@ -94,12 +114,12 @@ separate connections.
 If you don't pass in a curl handle to the \code{handle} parameter,
 it gets created when a HTTP verb is called. Thus, if you try to get \code{handle}
 after creating a \code{HttpClient} object only passing \code{url} parameter, \code{handle}
-will be \code{NULL}. If you pass a curl handle to the \code{handle parameter, then  you can get the handle from the }HttpClient\code{object. The response from a  http verb request does have the handle in the}handle` slot.
+will be \code{NULL}. If you pass a curl handle to the \code{handle parameter, then you can get the handle from the }HttpClient\code{object. The response from a http verb request does have the handle in the}handle` slot.
 }
 
 \examples{
 \dontrun{
-# set your own handle 
+# set your own handle
 (h <- handle("https://httpbin.org"))
 (x <- HttpClient$new(handle = h))
 x$handle
@@ -117,7 +137,7 @@ x$url
 x$handle # is empty, it gets created when a HTTP verb is called
 (r1 <- x$get('get'))
 x$url
-x$handle 
+x$handle
 r1$url
 r1$handle
 r1$content
@@ -146,6 +166,15 @@ x$post('post')
 
 # head request
 (res_head <- x$head())
+
+# retry, by default at most 3 times
+(res_get <- x$retry("GET", path = "status/400"))
+
+# retry, but not for 404 NOT FOUND
+(res_get <- x$retry("GET", path = "status/404", terminate_on = c(404)))
+
+# retry, but only for exceeding rate limit (note that e.g. Github uses 403)
+(res_get <- x$retry("GET", path = "status/429", retry_only_on = c(403, 429)))
 
 # query params are URL encoded for you, so DO NOT do it yourself
 ## if you url encode yourself, it gets double encoded, and that's bad

--- a/man/HttpClient.Rd
+++ b/man/HttpClient.Rd
@@ -48,7 +48,7 @@ Make a DELETE request
 \item{\code{head(path, query, ...)}}{
 Make a HEAD request
 }
-\item{\code{retry(verb, ..., pause_base = 1, pause_cap = 60, pause_min = 1, times = 3, terminate_on, retry_only_on)}}{
+\item{\code{retry(verb, ..., pause_base = 1, pause_cap = 60, pause_min = 1, times = 3, terminate_on, retry_only_on, onwait)}}{
 Retries the request given by \code{verb} until successful (HTTP response
 status < 400), or a condition for giving up is met. Automatically
 recognizes \code{Retry-After} and \code{X-RateLimit-Reset} headers in the
@@ -93,6 +93,11 @@ not stop retrying due to exhausting the number of attempts.
 \item \code{terminate_on,retry_only_on} - a vector of HTTP status codes. For
 \code{terminate_on}, the status codes for which to terminate retrying, and for
 \code{retry_only_on}, the status codes for which to retry the request.
+\item \code{onwait} - a callback function if the request will be retried and
+a wait time is being applied. The function will be passed two parameters,
+the response object from the failed request, and the wait time in seconds.
+Note that the time spent in the function effectively adds to the wait time,
+so it should be kept simple.
 }
 }
 \note{
@@ -114,12 +119,12 @@ separate connections.
 If you don't pass in a curl handle to the \code{handle} parameter,
 it gets created when a HTTP verb is called. Thus, if you try to get \code{handle}
 after creating a \code{HttpClient} object only passing \code{url} parameter, \code{handle}
-will be \code{NULL}. If you pass a curl handle to the \code{handle parameter, then you can get the handle from the }HttpClient\code{object. The response from a http verb request does have the handle in the}handle` slot.
+will be \code{NULL}. If you pass a curl handle to the \code{handle parameter, then  you can get the handle from the }HttpClient\code{object. The response from a  http verb request does have the handle in the}handle` slot.
 }
 
 \examples{
 \dontrun{
-# set your own handle
+# set your own handle 
 (h <- handle("https://httpbin.org"))
 (x <- HttpClient$new(handle = h))
 x$handle
@@ -137,7 +142,7 @@ x$url
 x$handle # is empty, it gets created when a HTTP verb is called
 (r1 <- x$get('get'))
 x$url
-x$handle
+x$handle 
 r1$url
 r1$handle
 r1$content

--- a/tests/testthat/test-mocking.R
+++ b/tests/testthat/test-mocking.R
@@ -19,10 +19,11 @@ test_that("mock function", {
 context("mocking: HttpClient")
 test_that("mocking with HttpClient", {
   skip_on_cran()
+  skip_if_not_installed("webmockr")
 
-  library(webmockr)
+  loadNamespace("webmockr")
   url <- hb()
-  st <- stub_request("get", file.path(url, "get"))
+  st <- webmockr::stub_request("get", file.path(url, "get"))
   #webmockr:::webmockr_stub_registry
 
   # webmockr IS NOT enabled
@@ -42,15 +43,19 @@ test_that("mocking with HttpClient", {
 
   expect_is(aa$times, "numeric")
   expect_null(bb$times)
+
+  # clean up
+  webmockr::stub_registry_clear()
 })
 
 context("mocking: HttpClient when not stubbed yet")
 test_that("mocking with HttpClient: ", {
   skip_on_cran()
+  skip_if_not_installed("webmockr")
 
-  library(webmockr)
+  loadNamespace("webmockr")
   url <- hb()
-  st <- stub_request("get", file.path(url, "get"))
+  st <- webmockr::stub_request("get", file.path(url, "get"))
   #webmockr:::webmockr_stub_registry
 
   # webmockr IS NOT enabled
@@ -67,6 +72,9 @@ test_that("mocking with HttpClient: ", {
     cli$post("post"),
     "registered request stubs"
   )
+
+  # clean up
+  webmockr::stub_registry_clear()
 })
 
 # turn mocking off

--- a/tests/testthat/test-retry.R
+++ b/tests/testthat/test-retry.R
@@ -261,7 +261,7 @@ test_that("retry recognizes retry headers", {
                               status = 429,
                               headers = list("x-ratelimit-remaining" = "0",
                                              "x-ratelimit-reset" =
-                                               as.character(as.integer(Sys.time()) + 3)))
+                                               ceiling(as.numeric(Sys.time())) + 3))
   tt1 <- system.time(cli$retry("GET", path = "get", pause_base = 0, pause_min = 0, times = 1))
   expect_gt(tt1["elapsed"], 2.0)
   webmockr::stub_registry_clear()

--- a/tests/testthat/test-retry.R
+++ b/tests/testthat/test-retry.R
@@ -1,0 +1,302 @@
+context("retry: basics")
+
+test_that("retry has basic error checking", {
+  cli <- HttpClient$new(url = hb())
+
+  expect_error(cli$retry())
+  expect_error(cli$retry(TRUE))
+  expect_error(cli$retry(times = 10))
+  expect_error(cli$retry("", times = 10))
+  expect_error(cli$retry("FOO", times = 10))
+})
+
+context("retry: get")
+
+test_that("retry wrapping get request works", {
+  skip_on_cran()
+
+  cli <- HttpClient$new(url = hb())
+  aa <- cli$retry("GET", path = "get")
+
+  expect_is(aa, "HttpResponse")
+  expect_is(aa$handle, 'curl_handle')
+  expect_is(aa$content, "raw")
+  expect_is(aa$method, "character")
+  expect_equal(aa$method, "get")
+  expect_is(aa$parse, "function")
+  expect_is(aa$parse(), "character")
+  expect_true(aa$success())
+})
+
+test_that("retry wrapping get request - query parameters", {
+  skip_on_cran()
+
+  cli <- HttpClient$new(url = hb())
+  querya <- list(a = "Asdfadsf", hello = "world")
+  aa <- cli$retry("GET", path = "get", query = querya)
+
+  expect_is(aa, "HttpResponse")
+  expect_is(aa$content, "raw")
+  expect_is(aa$method, "character")
+  expect_equal(aa$method, "get")
+  expect_is(aa$parse, "function")
+  expect_is(aa$parse(), "character")
+  expect_true(aa$success())
+
+  library(urltools)
+  params <- unlist(lapply(
+    strsplit(urltools::url_parse(aa$request$url$url)$parameter, "&")[[1]],
+    function(x) {
+      tmp <- strsplit(x, "=")[[1]]
+      as.list(stats::setNames(tmp[2], tmp[1]))
+    }
+  ), FALSE)
+  expect_equal(params, querya)
+})
+
+context("retry: post")
+
+test_that("retry wrapping post request works", {
+  skip_on_cran()
+
+  cli <- HttpClient$new(url = hb())
+  aa <- cli$retry("POST", path = "post")
+
+  expect_is(aa, "HttpResponse")
+  expect_is(aa$handle, 'curl_handle')
+  expect_is(aa$content, "raw")
+  expect_is(aa$method, "character")
+  expect_equal(aa$method, "post")
+  expect_is(aa$parse, "function")
+  expect_is(aa$parse(), "character")
+  expect_true(aa$success())
+
+  expect_null(aa$request$fields)
+})
+
+test_that("retry wrapping post request with body", {
+  skip_on_cran()
+
+  cli <- HttpClient$new(url = hb())
+  aa <- cli$retry("POST", path = "post", body = list(hello = "world"))
+
+  expect_is(aa, "HttpResponse")
+  expect_is(aa$handle, 'curl_handle')
+  expect_is(aa$content, "raw")
+  expect_is(aa$method, "character")
+  expect_equal(aa$method, "post")
+  expect_is(aa$parse, "function")
+  expect_is(aa$parse(), "character")
+  expect_true(aa$success())
+
+  expect_named(aa$request$fields, "hello")
+  expect_equal(aa$request$fields[[1]], "world")
+})
+
+
+test_that("retry wrapping post request with file upload", {
+  skip_on_cran()
+
+  # txt file
+  ## as file
+  file <- upload(system.file("CITATION"))
+  cli <- HttpClient$new(url = hb())
+  aa <- cli$retry("POST", path = "post", body = list(a = file))
+
+  expect_is(aa, "HttpResponse")
+  expect_is(aa$content, "raw")
+  expect_null(aa$request$options$readfunction)
+  out <- jsonlite::fromJSON(aa$parse("UTF-8"))
+  expect_named(out$files, "a")
+  expect_match(out$files$a, "bibentry")
+
+  ## as data
+  aa2 <- cli$retry("POST", path = "post", body = file)
+  expect_is(aa2, "HttpResponse")
+  expect_is(aa2$content, "raw")
+  expect_is(aa2$request$options$readfunction, "function")
+  out <- jsonlite::fromJSON(aa2$parse("UTF-8"))
+  expect_equal(length(out$files), 0)
+  expect_is(out$data, "character")
+  expect_match(out$data, "bibentry")
+
+
+  # binary file: jpeg
+  file <- upload(file.path(Sys.getenv("R_DOC_DIR"), "html/logo.jpg"))
+  cli <- HttpClient$new(url = hb())
+  aa <- cli$retry("POST", path = "post", body = list(a = file))
+
+  expect_is(aa, "HttpResponse")
+  expect_is(aa$content, "raw")
+  expect_named(aa$request$fields, "a")
+  out <- jsonlite::fromJSON(aa$parse("UTF-8"))
+  expect_named(out$files, "a")
+  expect_match(out$files$a, "data:image/jpeg")
+})
+
+context("retry: put")
+
+test_that("retry wrapping put request works", {
+  skip_on_cran()
+
+  cli <- HttpClient$new(url = hb())
+  aa <- cli$retry("PUT", path = "put")
+
+  expect_is(aa, "HttpResponse")
+  expect_is(aa$handle, 'curl_handle')
+  expect_is(aa$content, "raw")
+  expect_is(aa$method, "character")
+  expect_equal(aa$method, "put")
+  expect_is(aa$parse, "function")
+  expect_is(aa$parse(), "character")
+  expect_true(aa$success())
+
+  expect_null(aa$request$fields)
+})
+
+test_that("retry wrapping put request with body", {
+  skip_on_cran()
+
+  cli <- HttpClient$new(url = hb())
+  aa <- cli$retry("PUT", path = "put", body = list(hello = "world"))
+
+  expect_is(aa, "HttpResponse")
+  expect_is(aa$handle, 'curl_handle')
+  expect_is(aa$content, "raw")
+  expect_is(aa$method, "character")
+  expect_equal(aa$method, "put")
+  expect_is(aa$parse, "function")
+  expect_is(aa$parse("UTF-8"), "character")
+  expect_true(aa$success())
+
+  expect_named(aa$request$fields, "hello")
+  expect_equal(aa$request$fields[[1]], "world")
+})
+
+context("retry: delete")
+
+test_that("retry wrapping delete request works", {
+  skip_on_cran()
+
+  cli <- HttpClient$new(url = hb())
+  aa <- cli$retry("DELETE", path = "delete")
+
+  expect_is(aa, "HttpResponse")
+  expect_is(aa$handle, 'curl_handle')
+  expect_is(aa$content, "raw")
+  expect_is(aa$method, "character")
+  expect_equal(aa$method, "delete")
+  expect_is(aa$parse, "function")
+  expect_is(aa$parse(), "character")
+  expect_true(aa$success())
+
+  expect_null(aa$request$fields)
+})
+
+test_that("retry wrapping delete request with body", {
+  skip_on_cran()
+
+  cli <- HttpClient$new(url = hb())
+  aa <- cli$retry("DELETE", path = "delete", body = list(hello = "world"))
+
+  expect_is(aa, "HttpResponse")
+  expect_is(aa$handle, 'curl_handle')
+  expect_is(aa$content, "raw")
+  expect_is(aa$method, "character")
+  expect_equal(aa$method, "delete")
+  expect_is(aa$parse, "function")
+  expect_is(aa$parse("UTF-8"), "character")
+  expect_true(aa$success())
+
+  expect_named(aa$request$fields, "hello")
+  expect_equal(aa$request$fields[[1]], "world")
+})
+
+context("retry: retry")
+
+test_that("retry actually retries on error", {
+  skip_on_cran()
+
+  cli <- HttpClient$new(url = hb())
+  ## baseline time for comparison
+  tt <- system.time(cli$retry("GET", path = "status/200", times = 2))
+  ## try again if this took longer than expected
+  if (tt["elapsed"] > 1)
+    tt <- system.time(cli$retry("GET", path = "status/200", times = 2))
+
+  tt1 <- system.time(cli$retry("GET", path = "status/400", times = 2))
+  expect_gt(tt1["elapsed"] - tt["elapsed"], 2)
+
+})
+
+test_that("retry recognizes retry headers", {
+  skip_on_cran()
+  skip_if_not_installed("webmockr")
+
+  loadNamespace("webmockr")
+  webmockr::enable()
+  cli <- HttpClient$new(url = "http://httpbin.org")
+
+  stub <- webmockr::stub_request("get", "http://httpbin.org/get")
+  stub <- webmockr::to_return(stub,
+                              status = 503,
+                              headers = list("retry-after" = 1))
+  tt0 <- system.time(cli$retry("GET", path = "get", times = 0))
+  expect_lt(tt0["elapsed"], 0.5)
+
+  tt1 <- system.time(cli$retry("GET", path = "get", pause_base = 0, pause_min = 0, times = 2))
+  expect_gt(tt1["elapsed"], 2)
+  webmockr::stub_registry_clear()
+
+  stub <- webmockr::stub_request("get", "http://httpbin.org/get")
+  stub <- webmockr::to_return(stub,
+                              status = 429,
+                              headers = list("x-ratelimit-remaining" = "0", "retry-after" = "1"))
+  tt1 <- system.time(cli$retry("GET", path = "get", pause_base = 0, pause_min = 0, times = 2))
+  expect_gt(tt1["elapsed"], 2)
+  webmockr::stub_registry_clear()
+
+  stub <- webmockr::stub_request("get", "http://httpbin.org/get")
+  stub <- webmockr::to_return(stub,
+                              status = 429,
+                              headers = list("x-ratelimit-remaining" = "0",
+                                             "x-ratelimit-reset" =
+                                               as.character(as.integer(Sys.time()) + 3)))
+  tt1 <- system.time(cli$retry("GET", path = "get", pause_base = 0, pause_min = 0, times = 1))
+  expect_gt(tt1["elapsed"], 2.0)
+  webmockr::stub_registry_clear()
+
+  webmockr::disable()
+})
+
+test_that("retry doesn't retry on error unless triggered", {
+  skip_on_cran()
+
+  cli <- HttpClient$new(url = hb())
+  ## baseline time
+  tt <- system.time(cli$retry("GET", path = "status/200", times = 2))
+  ## try again if this took longer than expected
+  if (tt["elapsed"] > 1)
+    tt <- system.time(cli$retry("GET", path = "status/200", times = 2))
+
+  tt1 <- system.time(cli$retry("GET", path = "status/400", times = 0))
+  expect_lt(tt1["elapsed"], 2)
+  expect_lt(abs(tt1["elapsed"] - tt["elapsed"]), 1)
+
+  tt1 <- system.time(cli$retry("GET", path = "status/400", pause_cap = 0))
+  expect_lt(tt1["elapsed"], 2)
+  expect_lt(abs(tt1["elapsed"] - tt["elapsed"]), 1)
+
+  tt1 <- system.time(cli$retry("GET", path = "status/400", terminate_on = c(400)))
+  expect_lt(tt1["elapsed"], 2)
+  expect_lt(abs(tt1["elapsed"] - tt["elapsed"]), 1)
+
+  tt1 <- system.time(cli$retry("GET", path = "status/404", terminate_on = c(400, 404)))
+  expect_lt(tt1["elapsed"], 2)
+  expect_lt(abs(tt1["elapsed"] - tt["elapsed"]), 1)
+
+  tt1 <- system.time(cli$retry("GET", path = "status/404", retry_only_on = c(400)))
+  expect_lt(tt1["elapsed"], 2)
+  expect_lt(abs(tt1["elapsed"] - tt["elapsed"]), 1)
+
+})


### PR DESCRIPTION
## Description

Allows retrying HTTP requests after they fail (status code >= 400). The parameters for `retry()` are modeled after httr::RETRY(), and the wait time is calculated according to the same algorithm (exponential backoff with full jitter). It also uses the same defaults.

## Related Issue

See ropensci/taxize#722 for context and concrete use-case.

## Example

Reproduced from the documentation:
```R
x <- HttpClient$new(url = "https://httpbin.org")

# retry, by default at most 3 times
res_get <- x$retry("GET", path = "status/400")

# retry, but not for 404 NOT FOUND
res_get <- x$retry("GET", path = "status/404", terminate_on = c(404))

# retry, but only for exceeding rate limit (note that e.g. [Github uses 403](https://developer.github.com/v3/#rate-limiting), not [429](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429))
res_get <- x$retry("GET", path = "status/429", retry_only_on = c(403, 429))
```

## Known limitations

* The value of the `Retry-After` response header, if present, is assumed to be in seconds. However, the [spec allows it to be an HTTP date as well](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After).

~~* There is no call back function for allowing a client to message to the user if and how much waiting is being applied.~~

Addresses and closes #89.