### PR TITLE
Assert url_parse() input is a scalar character vector

### DIFF
--- a/R/make_url.R
+++ b/R/make_url.R
@@ -24,7 +24,7 @@ add_query <- function(x, url) {
       if (!inherits(x[[i]], "AsIs")) {
         x[[i]] <- curl::curl_escape(x[[i]])
       }
-      quer[[i]] <- paste(curl::curl_escape(names(x)[i]), 
+      quer[[i]] <- paste(curl::curl_escape(names(x)[i]),
         x[[i]], sep = "=")
     }
     parms <- paste0(quer, collapse = "&")
@@ -66,6 +66,7 @@ url_build <- function(url, path = NULL, query = NULL) {
 #' @export
 #' @rdname url_build
 url_parse <- function(url) {
+  stopifnot(length(url) == 1, is.character(url))
   tmp <- urltools::url_parse(url)
   tmp <- as.list(tmp)
   if (!is.na(tmp$parameter)) {

--- a/tests/testthat/test-url_build_parse.R
+++ b/tests/testthat/test-url_build_parse.R
@@ -85,6 +85,9 @@ test_that("parse fails well", {
   # url param required
   expect_error(url_build(), "argument \"url\" is missing")
 
+  # scalar character required
+  expect_error(url_parse(rep(hb(), 2)), "length\\(url\\) == 1 is not TRUE")
+
   # wrong types
   expect_error(url_build(5), "url must be of class character")
   expect_error(url_build("ASDf", path = 5), "path must be of class character")


### PR DESCRIPTION
This just adds an explicit assertion to help users avoid the mistake of passing multiple URLs to `url_parse()`. 

Here's the current behavior:

```r
crul::url_parse(rep("https://httpbin.org/get", 2))
```

```
$scheme
[1] "https" "https"

$domain
[1] "httpbin.org" "httpbin.org"

$port
[1] NA NA

$path
[1] "get" "get"

$parameter
[1] NA NA

$fragment
[1] NA NA

Warning message:
In if (!is.na(tmp$parameter)) { :
  the condition has length > 1 and only the first element will be used
```

Since it actually returns a result, the unsuspecting user may assume it's a vectorized function. At least I did... 😄


