### PR TITLE
make ok() error informative when fauxpas isn't installed

### DIFF
--- a/R/ok.R
+++ b/R/ok.R
@@ -51,14 +51,14 @@ ok.HttpClient <- function(x, status = 200L, info = TRUE, ...) {
   assert(info, "logical")
   assert(status, "integer")
   
-  if(!requireNamespace("fauxpas", quietly = TRUE)){
-    stop("The fauxpas package is required, please install it.",
-         call. = FALSE)
+  if (!requireNamespace("fauxpas", quietly = TRUE)) {
+    find_status <- tryCatch(httpcode::http_code(status), 
+                            error = function(e) e)
+    } else {
+    find_status <- tryCatch(fauxpas::find_error_class(status), 
+                            error = function(e) e)
   }
   
-  find_status <- tryCatch(fauxpas::find_error_class(status), 
-    error = function(e) e)
-  browser()
   if (inherits(find_status, "error")) stop("status [", status, "] not in acceptable set")
   w <- tryCatch(x$head(), error = function(e) e)
   if (inherits(w, "error")) {

--- a/R/ok.R
+++ b/R/ok.R
@@ -50,8 +50,15 @@ ok.character <- function(x, status = 200L, info = TRUE, ...) {
 ok.HttpClient <- function(x, status = 200L, info = TRUE, ...) {
   assert(info, "logical")
   assert(status, "integer")
+  
+  if(!requireNamespace("fauxpas", quietly = TRUE)){
+    stop("The fauxpas package is required, please install it.",
+         call. = FALSE)
+  }
+  
   find_status <- tryCatch(fauxpas::find_error_class(status), 
     error = function(e) e)
+  browser()
   if (inherits(find_status, "error")) stop("status [", status, "] not in acceptable set")
   w <- tryCatch(x$head(), error = function(e) e)
   if (inherits(w, "error")) {

--- a/R/ok.R
+++ b/R/ok.R
@@ -51,13 +51,8 @@ ok.HttpClient <- function(x, status = 200L, info = TRUE, ...) {
   assert(info, "logical")
   assert(status, "integer")
   
-  if (!requireNamespace("fauxpas", quietly = TRUE)) {
-    find_status <- tryCatch(httpcode::http_code(status), 
-                            error = function(e) e)
-    } else {
-    find_status <- tryCatch(fauxpas::find_error_class(status), 
-                            error = function(e) e)
-  }
+  find_status <- tryCatch(httpcode::http_code(status), 
+                          error = function(e) e)
   
   if (inherits(find_status, "error")) stop("status [", status, "] not in acceptable set")
   w <- tryCatch(x$head(), error = function(e) e)

--- a/tests/testthat/test-ok.R
+++ b/tests/testthat/test-ok.R
@@ -35,4 +35,6 @@ test_that("ok fails well", {
   expect_error(ok(mtcars), "no 'ok' method for data.frame")
   expect_error(ok(list()), "no 'ok' method for list")
   expect_error(ok(), "argument \"x\" is missing")
+  expect_error(ok(hb("/status/404"), status = 567L),
+               "not in acceptable set")
 })


### PR DESCRIPTION
cf #108

I'm not sure how to add a test.
* `requireNamespace` is a base function so cannot be mocked with `testthat::with_mock()` cf https://www.tidyverse.org/articles/2017/12/testthat-2-0-0/ so I'd need to add a dependency on `mockery` or `mockr`
* maybe I could make a `check_package()` function [like what `desc` has](https://github.com/r-lib/desc/blob/42b9578f374bf685610b1efb05315927ae236d5b/R/utils.R#L85) just so I can mock it with `with_mock`?