### PR TITLE
Format numbers so scientific notation isn't used in paging parameters

### DIFF
--- a/R/make_url.R
+++ b/R/make_url.R
@@ -22,7 +22,7 @@ add_query <- function(x, url) {
     quer <- list()
     for (i in seq_along(x)) {
       if (!inherits(x[[i]], "AsIs")) {
-        x[[i]] <- curl::curl_escape(x[[i]])
+        x[[i]] <- curl::curl_escape(num_format(x[[i]]))
       }
       quer[[i]] <- paste(curl::curl_escape(names(x)[i]),
         x[[i]], sep = "=")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -115,5 +115,5 @@ last <- function(x) {
 # Format numbers so they don't turn into scientific notation
 num_format <- function(x) {
   if (is.null(x) || !is.numeric(x)) return(x)
-  format(x, trim = TRUE, scientific = FALSE)
+  format(x, trim = TRUE, drop0trailing = TRUE, scientific = FALSE)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -111,3 +111,9 @@ last <- function(x) {
   if (length(x) == 0) return(list())
   x[[length(x)]]
 }
+
+# Format numbers so they don't turn into scientific notation
+num_format <- function(x) {
+  if (is.null(x) || !is.numeric(x)) return(x)
+  format(x, trim = TRUE, scientific = FALSE)
+}

--- a/tests/testthat/test-url_fetch.R
+++ b/tests/testthat/test-url_fetch.R
@@ -11,7 +11,7 @@ test_that("HttpClient url_fetch base url only", {
 
 test_that("HttpClient url_fetch with base url and path", {
   skip_on_cran()
- 
+
   expect_is(x$url_fetch('get'), "character")
   expect_match(x$url_fetch('get'), url)
   expect_match(x$url_fetch('get'), "/get")
@@ -21,7 +21,7 @@ test_that("HttpClient url_fetch with base url and path", {
   expect_match(x$url_fetch('post'), url)
   expect_match(x$url_fetch('post'), "/post")
   expect_match(x$url_fetch('post'), "http")
-  
+
   expect_is(x$url_fetch('post'), "character")
   expect_match(x$url_fetch('post'), url)
   expect_match(x$url_fetch('post'), "/post")
@@ -30,7 +30,7 @@ test_that("HttpClient url_fetch with base url and path", {
 
 test_that("HttpClient url_fetch with base url, path, query", {
   skip_on_cran()
- 
+
   out <- x$url_fetch('get', query = list(foo = "bar"))
 
   expect_is(out, "character")
@@ -55,7 +55,7 @@ context("paginator: url_fetch")
 cr_url <- "https://api.crossref.org"
 cli <- HttpClient$new(url = cr_url)
 aa <- Paginator$new(client = cli, by = "query_params", limit_param = "rows",
-  offset_param = "offset", limit = 50, limit_chunk = 10)
+  offset_param = "offset", limit = 500000, limit_chunk = 100000)
 test_that("Paginator url_fetch base url only", {
   skip_on_cran()
 
@@ -69,12 +69,12 @@ test_that("Paginator url_fetch base url only", {
   expect_match(aa$url_fetch(), "rows")
   # offset different for every url
   expect_match(aa$url_fetch()[1], "offset=0")
-  expect_match(aa$url_fetch()[2], "offset=10")
-  expect_match(aa$url_fetch()[3], "offset=20")
-  expect_match(aa$url_fetch()[4], "offset=30")
-  expect_match(aa$url_fetch()[5], "offset=40")
+  expect_match(aa$url_fetch()[2], "offset=100000")
+  expect_match(aa$url_fetch()[3], "offset=200000")
+  expect_match(aa$url_fetch()[4], "offset=300000")
+  expect_match(aa$url_fetch()[5], "offset=400000")
   # rows same for every url
-  expect_match(aa$url_fetch(), "rows=10")
+  expect_match(aa$url_fetch(), "rows=100000")
 })
 
 test_that("Paginator url_fetch with base url and path", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -47,3 +47,12 @@ test_that("curl_opts_check works", {
   expect_error(
     curl_opts_check(httppost = 1), "the following curl options are not allowed")
 })
+
+context("num_format")
+test_that("num_format works", {
+  expect_null(num_format(NULL))
+  expect_equal(num_format(c("hello", "goodbye")),
+               c("hello", "goodbye"))
+  expect_equal(num_format(c(11, 0.00005, 200000)),
+               c("11", "0.00005", "200000"))
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Our package [bcdata](https://github.com/bcgov/bcdata) uses {crul} to get spatial data from a WFS server - some of these are very large and require paged requests with rows into the hundreds of thousands. Scientific number formatting of paging parameters can sometimes result in requests looking like this (note the `startIndex` value):

```
https://openmaps.gov.bc.ca/geo/pub/wfs/?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&outputFormat=application%2Fjson&typeNames=WHSE_BASEMAPPING.FWA_WATERSHEDS_POLY&SRSNAME=EPSG%3A3005&sortby=OBJECTID&startIndex=1e%2B05&count=1000
```

This returns 1000 records, but doesn't start at the correct spot (I'm not totally sure how `1e+05` is interpreted by the server though I think it might just be ignored).

This fix formats numbers as character (avoiding scientific notation) when they are added to the query.

## Example
``` r
cr_url <- "https://api.crossref.org"
cli <- HttpClient$new(url = cr_url)
aa <- Paginator$new(client = cli, by = "query_params", limit_param = "rows",
                    offset_param = "offset", limit = 500000, limit_chunk = 100000)
aa$url_fetch()
#> [1] "https://api.crossref.org/?offset=0&rows=1e%2B05"      
#> [2] "https://api.crossref.org/?offset=1e%2B05&rows=1e%2B05"
#> [3] "https://api.crossref.org/?offset=2e%2B05&rows=1e%2B05"
#> [4] "https://api.crossref.org/?offset=3e%2B05&rows=1e%2B05"
#> [5] "https://api.crossref.org/?offset=4e%2B05&rows=1e%2B05"
```

With the submitted fix it looks like this:

``` r
cr_url <- "https://api.crossref.org"
cli <- HttpClient$new(url = cr_url)
aa <- Paginator$new(client = cli, by = "query_params", limit_param = "rows",
                    offset_param = "offset", limit = 500000, limit_chunk = 100000)
aa$url_fetch()
#> [1] "https://api.crossref.org/?offset=0&rows=100000"     
#> [2] "https://api.crossref.org/?offset=100000&rows=100000"
#> [3] "https://api.crossref.org/?offset=200000&rows=100000"
#> [4] "https://api.crossref.org/?offset=300000&rows=100000"
#> [5] "https://api.crossref.org/?offset=400000&rows=100000"
```

I also updated the `url_fetch()` tests to use larger numbers (that would be converted to scientific notation) and a test for the new utility function `num_format()`.

Addresses https://github.com/bcgov/bcdata/issues/235

