### PR TITLE
Try to handle headers with Latin1 encoding

### DIFF
--- a/R/client.R
+++ b/R/client.R
@@ -523,6 +523,10 @@ HttpClient <- R6::R6Class(
         headers <- list()
       } else {
         hh <- rawToChar(resp$headers %||% raw(0))
+        if (!validEnc(hh)) {
+          Encoding(hh) <- "latin1"
+          if (!validEnc(hh)) stop("Headers aren't encoded in UTF-8 or Latin1")
+        }
         if (is.null(hh) || nchar(hh) == 0) {
           headers <- list()
         } else {

--- a/crul.Rproj
+++ b/crul.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previous functionality: assume headers are UTF-8 encoded. New functionality: check if UTF-8 encoding is valid. If not, try Latin-1. If still not, throw an error specifying the issue.

## Related Issue
Fixes #163
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
Doesn't add features or change behavior; only a bug fix. 

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
Re: tests, I don't know how to make a request that returns Latin-1 encoding in the header besides using `rcrossref` functions (see #163), which doesn't seem like it translates directly to a test. Sorry!
