### PR TITLE
try adding test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Suggests:
     fauxpas (>= 0.1.0),
     webmockr (>= 0.1.0),
     knitr,
-    rmarkdown
+    rmarkdown,
+    magrittr
 VignetteBuilder: knitr
 RoxygenNote: 7.1.2
 X-schema.org-applicationCategory: Web

--- a/tests/testthat/test-retry-2.R
+++ b/tests/testthat/test-retry-2.R
@@ -1,0 +1,23 @@
+
+test_that("retry works if success then failure", {
+  skip_on_cran()
+  skip_if_not_installed("webmockr")
+  skip_if_not_installed("magrittr")
+
+  loadNamespace("webmockr")
+  webmockr::enable()
+  cli <- HttpClient$new(url = "http://bla.blop")
+
+  stub <- webmockr::stub_request("get", "http://bla.blop")
+  stub %>%
+    webmockr::to_return(status = 503) %>%
+    webmockr::to_return(status = 200, body = "{\n  \"args\": {}, \n  \"headers\": {\n    \"Accept\": \"application/json,
+        text/xml, application/xml, */*\", \n    \"Accept-Encoding\": \"gzip, deflate\",
+        \n    \"Connection\": \"close\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\":
+        \"libcurl/7.54.0 r-curl/3.2 crul/0.5.2\"\n  }, \n  \"origin\": \"111.222.333.444\",
+        \n  \"url\": \"https://eu.httpbin.org/get\"\n}\n", headers = list(b = 6))
+  expect_message(thing <- cli$retry("get", onwait = function(resp, secs) {message("retry message")}), "retry message")
+    expect_equal(thing$status_code, 200)
+
+
+})


### PR DESCRIPTION
Fix #137

* In a separate file for now as it was easier.
* Not sure whether piping is useful.
* Should the other test-retry file be split since the use of `context()` is no longer recommended?
* Is this really what I meant by using then :thinking: 